### PR TITLE
Update project report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Depends:
     mrprom
 Imports: gdx, madrat, magclass, stringr, quitte, rlang, plotly, flexdashboard,
          tidyr, dplyr, purrr, ggplot2, rmarkdown, knitr, mip,
-         piamValidation, rmarkdown, pandoc, grDevices, grid, gridExtra
+         piamValidation, rmarkdown, pandoc, grDevices, grid, gridExtra, writexl
 RoxygenNote: 7.3.3
 Suggests:
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: postprom
 Type: Package
 Title: A Tool for Comparative Analysis of OPEN-PROM Data
-Version: 0.12.8
+Version: 0.12.9
 Authors@R: c(
     person(
       "Michael", "Madianos",

--- a/R/convertGDXtoMIF.R
+++ b/R/convertGDXtoMIF.R
@@ -7,6 +7,9 @@
 #' @param regions Optional; a character vector specifying the regions to include. Defaults to `NULL`, in which case regions are read from the GDX file.
 #' @param fullValidation Optional; a logical value indicating whether full validation should be performed. Defaults to `TRUE`.
 #' @param scenario_name Optional; a character vector specifying the scenario names. Defaults to the basename of `.path`.
+#' @param model Optional; model name written to MIF/project-report outputs. Defaults to `"OPEN-PROM"`.
+#' @param project_template Optional; project template filename or path used by
+#'   `projectReport`. If `NULL`, project reporting is skipped.
 #' @param aggregate Optional; a logical value indicating whether to aggregate data. Defaults to `TRUE`.
 #' @param save Optional; a logical value indicating whether to save the output. Defaults to `TRUE`.
 #' @param emissions Optional; a logical value indicating whether to generate a separate emissions csv file for running climate assessment. Defaults to `TRUE`.
@@ -26,6 +29,8 @@
 #'   regions = c("runCYL", "World"),
 #'   fullValidation = TRUE,
 #'   scenario_name = c("Scenario1", "Scenario2"),
+#'   model = "OPEN-PROM",
+#'   project_template = "project-template.csv",
 #'   aggregate = TRUE,
 #'   emissions = TRUE,
 #'   save = TRUE,
@@ -38,9 +43,16 @@
 #' @export
 convertGDXtoMIF <- function(.path, mif_name, regions = NULL, years = NULL,
                             fullValidation = TRUE, scenario_name = NULL,
-                            aggregate = TRUE, emissions = TRUE, save = TRUE,
-                            htmlReport = FALSE, projectReport = FALSE) {
+                            model = "OPEN-PROM", aggregate = TRUE,
+                            emissions = TRUE, save = TRUE, htmlReport = FALSE,
+                            projectReport = FALSE,
+                            project_template = "project-template.csv") {
   if (is.null(scenario_name)) scenario_name <- basename(.path)
+  if (is.character(projectReport) && length(projectReport) == 1) {
+    project_template <- projectReport
+    projectReport <- TRUE
+  }
+  if (is.null(projectReport) || is.null(project_template)) projectReport <- FALSE
   current_time <- format(Sys.time(), "%Y-%m-%d_%H-%M")
   append <- length(.path) > 1
   path_mif <- file.path(
@@ -56,6 +68,7 @@ convertGDXtoMIF <- function(.path, mif_name, regions = NULL, years = NULL,
         years = years,
         path_mif = path_mif,
         scenario_name = scenario,
+        model = model,
         aggregate = aggregate,
         append = append,
         save = save,
@@ -71,11 +84,14 @@ convertGDXtoMIF <- function(.path, mif_name, regions = NULL, years = NULL,
 
   if (fullValidation == TRUE) appendValidationMIF(.path[1], path_mif)
   if (save == TRUE && projectReport == TRUE) {
-    projectReport(
+    projectReportFunction <- get("projectReport", mode = "function")
+    projectReportFunction(
       .path = dirname(path_mif),
       openPromVariables = scenarios_reports,
       openPromFile = path_mif,
-      scenario_name = scenario_name
+      scenario_name = scenario_name,
+      model = model,
+      project_template = project_template
     )
   }
 
@@ -84,7 +100,8 @@ convertGDXtoMIF <- function(.path, mif_name, regions = NULL, years = NULL,
 # Helpers -----------------------------------------------------------------
 convertGDXtoMIF_single <- function(.path, path_mif, append, regions = NULL,
                                    years = NULL, scenario_name = NULL,
-                                   aggregate = TRUE, emissions = TRUE, save = TRUE,
+                                   model = "OPEN-PROM", aggregate = TRUE,
+                                   emissions = TRUE, save = TRUE,
                                    htmlReport = TRUE, projectReport = TRUE,
                                    dashboard = TRUE) {
   print(paste0("Region aggregation: ", aggregate))
@@ -134,7 +151,7 @@ convertGDXtoMIF_single <- function(.path, path_mif, append, regions = NULL,
     write.report(
       reports,
       file = path_mif,
-      model = "OPEN-PROM",
+      model = model,
       scenario = scenario_name,
       append = append
     )

--- a/R/convertGDXtoMIF.R
+++ b/R/convertGDXtoMIF.R
@@ -61,14 +61,23 @@ convertGDXtoMIF <- function(.path, mif_name, regions = NULL, years = NULL,
         save = save,
         emissions = emissions,
         htmlReport = htmlReport,
-        projectReport = projectReport
+        projectReport = FALSE
       )
     },
     .path, scenario_name,
     SIMPLIFY = FALSE
   )
+  names(scenarios_reports) <- scenario_name
 
   if (fullValidation == TRUE) appendValidationMIF(.path[1], path_mif)
+  if (save == TRUE && projectReport == TRUE) {
+    projectReport(
+      .path = dirname(path_mif),
+      openPromVariables = scenarios_reports,
+      openPromFile = path_mif,
+      scenario_name = scenario_name
+    )
+  }
 
   return(scenarios_reports)
 }
@@ -132,7 +141,6 @@ convertGDXtoMIF_single <- function(.path, path_mif, append, regions = NULL,
     print(paste0("Saving mif file in ", path_mif))
     
     if (htmlReport == TRUE) htmlReportValidation(.path, path_mif)
-    if (projectReport == TRUE) projectReport(.path, path_mif)
     
     if (dashboard == TRUE & htmlReport == TRUE) rmarkdown::render(
       system.file("rmd", "dashboard.Rmd", package = "postprom"),

--- a/R/convertGDXtoMIF.R
+++ b/R/convertGDXtoMIF.R
@@ -45,14 +45,11 @@ convertGDXtoMIF <- function(.path, mif_name, regions = NULL, years = NULL,
                             fullValidation = TRUE, scenario_name = NULL,
                             model = "OPEN-PROM", aggregate = TRUE,
                             emissions = TRUE, save = TRUE, htmlReport = FALSE,
-                            projectReport = FALSE,
+                            projectReport = TRUE,
                             project_template = "project-template.csv") {
   if (is.null(scenario_name)) scenario_name <- basename(.path)
-  if (is.character(projectReport) && length(projectReport) == 1) {
-    project_template <- projectReport
-    projectReport <- TRUE
-  }
-  if (is.null(projectReport) || is.null(project_template)) projectReport <- FALSE
+  if (is.null(project_template)) projectReport <- FALSE
+  
   current_time <- format(Sys.time(), "%Y-%m-%d_%H-%M")
   append <- length(.path) > 1
   path_mif <- file.path(

--- a/R/projectReport.R
+++ b/R/projectReport.R
@@ -4,16 +4,19 @@
 #' units, keeps five-year periods, removes EU aggregate regions, and writes one
 #' concatenated project report for all supplied scenarios.
 #'
-#' @param .path A run path used to locate `../project-template.csv` and write the
+#' @param .path A run path used to locate the project template and write the
 #'   output files.
-#' @param openPromVariables A MAgPIE object, a named list of MAgPIE objects, or a
-#'   `read.report()`-style nested list (`scenario -> model -> magpie`).
+#' @param openPromVariables A MAgPIE object, a named list of MAgPIE objects, a
+#'   `read.report()`-style nested list (`scenario -> model -> magpie`), or a MIF
+#'   path for backwards-compatible file input.
 #' @param openPromFile Optional MIF file path to check and use as fallback input
 #'   when `openPromVariables` is `NULL`.
 #' @param scenario_name Optional scenario name(s). Required for unnamed single
 #'   MAgPIE object input.
 #' @param model Model name to use when it cannot be detected from nested input.
 #' @param output_basename Base name for the written `.mif` and `.xlsx` files.
+#' @param project_template Project template filename or path. If `NULL`, the
+#'   project report is skipped.
 #' @return Invisibly returns a list with output paths and the prepared tables.
 #'
 #' @examples
@@ -29,7 +32,19 @@
 #' @export
 projectReport <- function(.path, openPromVariables = NULL, openPromFile = NULL,
                           scenario_name = NULL, model = "OPEN-PROM",
-                          output_basename = "outputForProject") {
+                          output_basename = "outputForProject",
+                          project_template = "project-template.csv") {
+
+  if (is.null(project_template)) {
+    message("Skipping project report: 'project_template' is NULL.")
+    return(invisible(NULL))
+  }
+
+  if (is.character(openPromVariables) && length(openPromVariables) == 1 &&
+      is.null(openPromFile) && is.null(scenario_name)) {
+    openPromFile <- openPromVariables
+    openPromVariables <- NULL
+  }
 
   if (!is.null(openPromFile) && !file.exists(openPromFile)) {
     stop("Error: The data file '", openPromFile, "' does not exist.\n",
@@ -43,12 +58,7 @@ projectReport <- function(.path, openPromVariables = NULL, openPromFile = NULL,
     openPromVariables <- read.report(openPromFile)
   }
 
-  templatePath <- file.path(.path, "..", "project-template.csv")
-
-  if (!file.exists(templatePath)) {
-    stop("Error: Could not find project-template.csv at: ",
-         normalizePath(templatePath, mustWork = FALSE))
-  }
+  templatePath <- findProjectTemplatePath(.path, project_template)
 
   project <- read.csv(templatePath)
   map <- toolGetMapping(name = "prom-project-template.csv", where = "postprom")
@@ -143,6 +153,24 @@ normalizeProjectReportInput <- function(openPromVariables, scenario_name = NULL,
   }
 
   return(reports)
+}
+
+findProjectTemplatePath <- function(.path, project_template = "project-template.csv") {
+  candidates <- unique(c(
+    project_template,
+    file.path(.path, project_template),
+    file.path(dirname(.path), project_template)
+  ))
+  existing <- candidates[file.exists(candidates)]
+
+  if (length(existing)) {
+    return(existing[1])
+  }
+
+  stop(
+    "Error: Could not find project template '", project_template, "'. Checked: ",
+    paste(normalizePath(candidates, mustWork = FALSE), collapse = "; ")
+  )
 }
 
 prepareProjectReportScenario <- function(dataMagpie, project, map) {

--- a/R/projectReport.R
+++ b/R/projectReport.R
@@ -1,88 +1,188 @@
-#' Create a project-ready MIF report from OPEN-PROM results
+#' Create a project-ready report from OPEN-PROM results
 #'
-#' Reads an OPEN-PROM MIF output file, renames variables to match a project
-#' template using a mapping table, checks units against the project template,
-#' converts mismatching units (where supported), and writes a standardized MIF
-#' report (`outputForProject.mif`) for downstream use.
-#' 
-#' @param openPromFile A mif file that contains OPEN-PROM results.
-#' @return This function creates a report file specific to each project needs
+#' Renames OPEN-PROM variables to match a project template, checks and converts
+#' units, keeps five-year periods, removes EU aggregate regions, and writes one
+#' concatenated project report for all supplied scenarios.
+#'
+#' @param .path A run path used to locate `../project-template.csv` and write the
+#'   output files.
+#' @param openPromVariables A MAgPIE object, a named list of MAgPIE objects, or a
+#'   `read.report()`-style nested list (`scenario -> model -> magpie`).
+#' @param openPromFile Optional MIF file path to check and use as fallback input
+#'   when `openPromVariables` is `NULL`.
+#' @param scenario_name Optional scenario name(s). Required for unnamed single
+#'   MAgPIE object input.
+#' @param model Model name to use when it cannot be detected from nested input.
+#' @param output_basename Base name for the written `.mif` and `.xlsx` files.
+#' @return Invisibly returns a list with output paths and the prepared tables.
 #'
 #' @examples
 #' \dontrun{
-#' projectReport(.path = "path/to/run", "path/to/mif")
+#' projectReport(.path = "path/to/run", openPromVariables = reports,
+#'               scenario_name = "Scenario1")
+#' projectReport(.path = "path/to/run", openPromFile = "path/to/reporting.mif")
 #' }
-#' 
-#' @importFrom magclass mbind dimSums getItems getRegions write.report read.report
-#' @importFrom dplyr filter pull
+#'
+#' @importFrom magclass getItems getRegions getYears is.magpie mbind read.report write.report
+#' @importFrom dplyr bind_rows
 #' @importFrom utils read.csv
 #' @export
-projectReport <- function(.path, openPromFile) {
+projectReport <- function(.path, openPromVariables = NULL, openPromFile = NULL,
+                          scenario_name = NULL, model = "OPEN-PROM",
+                          output_basename = "outputForProject") {
 
-  if (!file.exists(openPromFile)) {
+  if (!is.null(openPromFile) && !file.exists(openPromFile)) {
     stop("Error: The data file '", openPromFile, "' does not exist.\n",
          "Current working directory: ", getwd())
   }
-  # --- Read data ---
-  dataMagpie <- read.report(openPromFile)
-  scenarioName <- names(dataMagpie)[1]
-  modelName <- names(dataMagpie[[1]])[1]
-  dataMagpie <- dataMagpie[[1]][[1]]
+
+  if (is.null(openPromVariables)) {
+    if (is.null(openPromFile)) {
+      stop("Either 'openPromVariables' or 'openPromFile' must be provided.")
+    }
+    openPromVariables <- read.report(openPromFile)
+  }
 
   templatePath <- file.path(.path, "..", "project-template.csv")
- 
-  # Safety check before reading
+
   if (!file.exists(templatePath)) {
-    stop("Error: Could not find project-template.csv at: ", normalizePath(templatePath, mustWork = FALSE))
+    stop("Error: Could not find project-template.csv at: ",
+         normalizePath(templatePath, mustWork = FALSE))
   }
 
   project <- read.csv(templatePath)
-  #project <- read.csv("..\\project-template.csv")
-
-  # --- Mapping ---
   map <- toolGetMapping(name = "prom-project-template.csv", where = "postprom")
+  reports <- normalizeProjectReportInput(openPromVariables, scenario_name, model)
 
-  # --- Extract variable names and units ---
+  outputMif <- file.path(.path, paste0(output_basename, ".mif"))
+  outputXlsx <- file.path(.path, paste0(output_basename, ".xlsx"))
+  xlsxTables <- list()
+
+  for (i in seq_along(reports)) {
+    reportInfo <- reports[[i]]
+    finalDataMagpie <- prepareProjectReportScenario(reportInfo$object, project, map)
+
+    write.report(
+      finalDataMagpie,
+      file = outputMif,
+      model = reportInfo$model,
+      scenario = reportInfo$scenario,
+      append = i > 1
+    )
+
+    xlsxTables[[i]] <- write.report(
+      finalDataMagpie,
+      file = NULL,
+      model = reportInfo$model,
+      scenario = reportInfo$scenario
+    )
+  }
+
+  xlsxTable <- bind_rows(xlsxTables)
+  writexl::write_xlsx(xlsxTable, outputXlsx)
+
+  message(paste0("Saving project mif file in ", outputMif))
+  message(paste0("Saving project xlsx file in ", outputXlsx))
+
+  invisible(list(mif = outputMif, xlsx = outputXlsx, table = xlsxTable))
+}
+
+normalizeProjectReportInput <- function(openPromVariables, scenario_name = NULL,
+                                        model = "OPEN-PROM") {
+  if (is.magpie(openPromVariables)) {
+    if (is.null(scenario_name) || length(scenario_name) != 1) {
+      stop("'scenario_name' must be supplied for a single MAgPIE object.")
+    }
+    return(list(list(
+      scenario = scenario_name,
+      model = model,
+      object = openPromVariables
+    )))
+  }
+
+  if (!is.list(openPromVariables)) {
+    stop("'openPromVariables' must be a MAgPIE object or a list of MAgPIE objects.")
+  }
+
+  reports <- list()
+
+  for (scenarioIndex in seq_along(openPromVariables)) {
+    scenarioObject <- openPromVariables[[scenarioIndex]]
+    scenario <- names(openPromVariables)[scenarioIndex]
+
+    if (is.null(scenario) || !nzchar(scenario)) {
+      if (!is.null(scenario_name) && length(scenario_name) >= scenarioIndex) {
+        scenario <- scenario_name[scenarioIndex]
+      } else {
+        scenario <- paste0("scenario", scenarioIndex)
+      }
+    }
+
+    if (is.magpie(scenarioObject)) {
+      reports[[length(reports) + 1]] <- list(
+        scenario = scenario,
+        model = model,
+        object = scenarioObject
+      )
+    } else if (is.list(scenarioObject)) {
+      for (modelName in names(scenarioObject)) {
+        magpieObject <- scenarioObject[[modelName]]
+        if (!is.magpie(magpieObject)) next
+
+        reports[[length(reports) + 1]] <- list(
+          scenario = scenario,
+          model = if (nzchar(modelName)) modelName else model,
+          object = magpieObject
+        )
+      }
+    }
+  }
+
+  if (!length(reports)) {
+    stop("No MAgPIE reports found in 'openPromVariables'.")
+  }
+
+  return(reports)
+}
+
+prepareProjectReportScenario <- function(dataMagpie, project, map) {
+  dataMagpie <- flattenProjectReportNames(dataMagpie)
+
   varNames <- getItems(dataMagpie, dim = 3)
-  varsClean <- trimws(gsub("\\s*\\(.*\\)$", "", varNames))
-  units <- gsub(".*\\((.*)\\)$", "\\1", varNames)
-  hasUnits <- grepl("\\(.*\\)$", varNames)
+  varsClean <- cleanProjectReportVariable(varNames)
+  units <- extractProjectReportUnit(varNames)
+  hasUnits <- !is.na(units)
 
-  # --- Rename setup ---
   map$OPEN_PROM <- trimws(map$OPEN_PROM)
-  rename_lookup <- setNames(map$project_template, map$OPEN_PROM)
+  rename_lookup <- setNames(trimws(map$project_template), map$OPEN_PROM)
 
-  # --- Rename variables ---
-  renamedVars <- ifelse(varsClean %in% names(rename_lookup),
-                        rename_lookup[varsClean],
-                        varsClean)
+  renamedVars <- varsClean
+  matchedVars <- varsClean %in% names(rename_lookup)
+  renamedVars[matchedVars] <- rename_lookup[varsClean[matchedVars]]
 
-  # --- Preserve units ---
-  renamedVarsFinal <- ifelse(hasUnits, paste0(renamedVars, " (", units, ")"), renamedVars)
-
-  # --- Apply names to magpie object ---
+  renamedVarsFinal <- renamedVars
+  renamedVarsFinal[hasUnits] <- paste0(renamedVars[hasUnits], " (", units[hasUnits], ")")
   getItems(dataMagpie, dim = 3) <- renamedVarsFinal
 
-  # --- Clean renamed variable list ---
-  renamedClean <- gsub("\\s*\\(.*\\)$", "", renamedVarsFinal)
+  renamedClean <- cleanProjectReportVariable(renamedVarsFinal)
+  commonVars <- intersect(project$variable, renamedClean)
 
-  # --- Intersection with project variables ---
-  commonVars <- intersect(renamedClean, project$variable)
+  if (!length(commonVars)) {
+    stop("No project-template variables were found in the OPEN-PROM report.")
+  }
 
-  # --- Find indices in magpie object ---
-  keepIndices <- match(commonVars, renamedClean)
-
-  # --- Extract current units (after rename) ---
   currentVarNames <- getItems(dataMagpie, dim = 3)
-  currentUnits <- gsub(".*\\((.*)\\)$", "\\1", currentVarNames)
-  currentUnits[!grepl("\\(.*\\)$", currentVarNames)] <- NA
+  currentClean <- cleanProjectReportVariable(currentVarNames)
+  currentUnits <- extractProjectReportUnit(currentVarNames)
+  namesByVariable <- setNames(currentVarNames, currentClean)
+  unitsByVariable <- setNames(currentUnits, currentClean)
+  keepNames <- unname(namesByVariable[commonVars])
 
-  # --- Get expected units from project ---
   expectedUnits <- project$unit[match(commonVars, project$variable)]
-  commonUnits <- currentUnits[keepIndices]
+  commonUnits <- unname(unitsByVariable[commonVars])
   unitMatch <- commonUnits == expectedUnits
+  unitMatch[is.na(unitMatch)] <- FALSE
 
-  # --- Build units table for checking---
   checkUnits <- data.frame(
     variable = commonVars,
     magpieUnit = commonUnits,
@@ -90,40 +190,64 @@ projectReport <- function(.path, openPromFile) {
     unitMatches = unitMatch,
     stringsAsFactors = FALSE
   )
-  filteredMagpie <- dataMagpie[, , keepIndices]
 
-  # Run the conversion of units
-  usd2015to2010 <- 0.9253 # https://www.in2013dollars.com/us/inflation/2015?amount=15&endYear=2010
+  filteredMagpie <- dataMagpie[, , keepNames]
 
+  usd2015to2010 <- 0.9253
   finalResults <- convertUnitsToExpected(
-    magpieObj  = filteredMagpie,
-    unitTable  = checkUnits,
-    usd2015to2010  = usd2015to2010,
+    magpieObj = filteredMagpie,
+    unitTable = checkUnits,
+    usd2015to2010 = usd2015to2010,
     allowUnrecognized = FALSE,
-    quiet  = TRUE
-    )
-  #print(finalResults$log)
+    quiet = TRUE
+  )
 
-  # Add variables from the project needs as 0 values. 
-  # Select multiple tiers and get variable and units as vectors
-  selectedVariables <- project %>%
-  filter(tier %in% c(1, 2)) %>%
-  pull(variable)
-  selectedUnits <- project %>%
-  filter(tier %in% c(1, 2)) %>%
-  pull(unit)
+  finalDataMagpie <- finalResults$object
+  finalDataMagpie <- filterProjectReportRegions(finalDataMagpie)
+  finalDataMagpie <- filterProjectReportYears(finalDataMagpie)
 
-  combinedVector <- paste(selectedVariables, selectedUnits, sep = " (")  # needed formatting for units
-  combinedVector <- paste0(combinedVector, ")") 
+  return(mbind(finalDataMagpie))
+}
 
-  allRegions <- getRegions(finalResults$object)
-  allYears <- getYears(finalResults$object)
+flattenProjectReportNames <- function(dataMagpie) {
+  fullNames <- getItems(dataMagpie, dim = 3)
 
-  tierMagpie <- new.magpie(cells = allRegions, years = allYears, names  = combinedVector, fill = 0)
-  names(dimnames(tierMagpie))[3] <- "variable"
+  if (any(grepl("\\(.*\\)$", fullNames))) {
+    return(dataMagpie)
+  }
 
-  #finalDataMagpie <- mbind(finalResults$object,tierMagpie)
-  finalDataMagpie <- mbind(finalResults$object)
-  write.report(finalDataMagpie,file.path(.path,"outputForProject.mif"), model = "OPEN-PROM 2.0", scenario = scenarioName)
-  message(paste0("Saving project mif file in ", .path))
+  splitNames <- strsplit(fullNames, "\\.")
+  flattenedNames <- vapply(splitNames, function(parts) {
+    if (length(parts) < 2) return(parts[1])
+
+    variable <- paste(parts[-length(parts)], collapse = ".")
+    unit <- parts[length(parts)]
+    paste0(variable, " (", unit, ")")
+  }, character(1))
+
+  getItems(dataMagpie, dim = 3) <- flattenedNames
+  return(dataMagpie)
+}
+
+cleanProjectReportVariable <- function(x) {
+  trimws(gsub("\\s*\\(.*\\)$", "", x))
+}
+
+extractProjectReportUnit <- function(x) {
+  out <- rep(NA_character_, length(x))
+  hasUnits <- grepl("\\(.*\\)$", x)
+  out[hasUnits] <- gsub(".*\\((.*)\\)$", "\\1", x[hasUnits])
+  return(out)
+}
+
+filterProjectReportRegions <- function(dataMagpie) {
+  euAggregates <- c("EU", "EU27", "EU28", "Europe")
+  keepRegions <- setdiff(getRegions(dataMagpie), euAggregates)
+  return(dataMagpie[keepRegions, , ])
+}
+
+filterProjectReportYears <- function(dataMagpie) {
+  yearsInt <- getYears(dataMagpie, as.integer = TRUE)
+  keepYears <- getYears(dataMagpie)[yearsInt %% 5 == 0]
+  return(dataMagpie[, keepYears, ])
 }

--- a/R/projectReport.R
+++ b/R/projectReport.R
@@ -17,6 +17,8 @@
 #' @param output_basename Base name for the written `.mif` and `.xlsx` files.
 #' @param project_template Project template filename or path. If `NULL`, the
 #'   project report is skipped.
+#' @param stripScenarioTimestamp Logical; remove trailing timestamps like
+#'   `_2026-05-11_16-57-15` from project-report scenario names.
 #' @return Invisibly returns a list with output paths and the prepared tables.
 #'
 #' @examples
@@ -33,7 +35,8 @@
 projectReport <- function(.path, openPromVariables = NULL, openPromFile = NULL,
                           scenario_name = NULL, model = "OPEN-PROM",
                           output_basename = "outputForProject",
-                          project_template = "project-template.csv") {
+                          project_template = "project-template.csv",
+                          stripScenarioTimestamp = TRUE) {
 
   if (is.null(project_template)) {
     message("Skipping project report: 'project_template' is NULL.")
@@ -63,6 +66,9 @@ projectReport <- function(.path, openPromVariables = NULL, openPromFile = NULL,
   project <- read.csv(templatePath)
   map <- toolGetMapping(name = "prom-project-template.csv", where = "postprom")
   reports <- normalizeProjectReportInput(openPromVariables, scenario_name, model)
+  if (stripScenarioTimestamp) {
+    reports <- stripProjectReportScenarioTimestamps(reports)
+  }
 
   outputMif <- file.path(.path, paste0(output_basename, ".mif"))
   outputXlsx <- file.path(.path, paste0(output_basename, ".xlsx"))
@@ -150,6 +156,18 @@ normalizeProjectReportInput <- function(openPromVariables, scenario_name = NULL,
 
   if (!length(reports)) {
     stop("No MAgPIE reports found in 'openPromVariables'.")
+  }
+
+  return(reports)
+}
+
+stripProjectReportScenarioTimestamps <- function(reports) {
+  for (i in seq_along(reports)) {
+    reports[[i]]$scenario <- sub(
+      "_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}$",
+      "",
+      reports[[i]]$scenario
+    )
   }
 
   return(reports)

--- a/man/convertGDXtoMIF.Rd
+++ b/man/convertGDXtoMIF.Rd
@@ -11,11 +11,13 @@ convertGDXtoMIF(
   years = NULL,
   fullValidation = TRUE,
   scenario_name = NULL,
+  model = "OPEN-PROM",
   aggregate = TRUE,
   emissions = TRUE,
   save = TRUE,
   htmlReport = FALSE,
-  projectReport = FALSE
+  projectReport = FALSE,
+  project_template = "project-template.csv"
 )
 }
 \arguments{
@@ -28,6 +30,11 @@ convertGDXtoMIF(
 \item{fullValidation}{Optional; a logical value indicating whether full validation should be performed. Defaults to `TRUE`.}
 
 \item{scenario_name}{Optional; a character vector specifying the scenario names. Defaults to the basename of `.path`.}
+
+\item{model}{Optional; model name written to MIF/project-report outputs. Defaults to \code{"OPEN-PROM"}.}
+
+\item{project_template}{Optional; project template filename or path used by
+\code{projectReport}. If \code{NULL}, project reporting is skipped.}
 
 \item{aggregate}{Optional; a logical value indicating whether to aggregate data. Defaults to `TRUE`.}
 
@@ -56,6 +63,8 @@ convertGDXtoMIF(
   regions = c("runCYL", "World"),
   fullValidation = TRUE,
   scenario_name = c("Scenario1", "Scenario2"),
+  model = "OPEN-PROM",
+  project_template = "project-template.csv",
   aggregate = TRUE,
   emissions = TRUE,
   save = TRUE,

--- a/man/projectReport.Rd
+++ b/man/projectReport.Rd
@@ -11,7 +11,8 @@ projectReport(
   scenario_name = NULL,
   model = "OPEN-PROM",
   output_basename = "outputForProject",
-  project_template = "project-template.csv"
+  project_template = "project-template.csv",
+  strip_scenario_timestamp = TRUE
 )
 }
 \arguments{
@@ -34,6 +35,9 @@ MAgPIE object input.}
 
 \item{project_template}{Project template filename or path. If \code{NULL}, the
 project report is skipped.}
+
+\item{strip_scenario_timestamp}{Logical; remove trailing timestamps like
+\code{_2026-05-11_16-57-15} from project-report scenario names.}
 }
 \value{
 Invisibly returns a list with output paths and the prepared tables.

--- a/man/projectReport.Rd
+++ b/man/projectReport.Rd
@@ -10,15 +10,17 @@ projectReport(
   openPromFile = NULL,
   scenario_name = NULL,
   model = "OPEN-PROM",
-  output_basename = "outputForProject"
+  output_basename = "outputForProject",
+  project_template = "project-template.csv"
 )
 }
 \arguments{
-\item{.path}{A run path used to locate \code{../project-template.csv} and write the
+\item{.path}{A run path used to locate the project template and write the
 output files.}
 
-\item{openPromVariables}{A MAgPIE object, a named list of MAgPIE objects, or a
-\code{read.report()}-style nested list (\code{scenario -> model -> magpie}).}
+\item{openPromVariables}{A MAgPIE object, a named list of MAgPIE objects, a
+\code{read.report()}-style nested list (\code{scenario -> model -> magpie}), or a MIF
+path for backwards-compatible file input.}
 
 \item{openPromFile}{Optional MIF file path to check and use as fallback input
 when \code{openPromVariables} is \code{NULL}.}
@@ -29,6 +31,9 @@ MAgPIE object input.}
 \item{model}{Model name to use when it cannot be detected from nested input.}
 
 \item{output_basename}{Base name for the written \code{.mif} and \code{.xlsx} files.}
+
+\item{project_template}{Project template filename or path. If \code{NULL}, the
+project report is skipped.}
 }
 \value{
 Invisibly returns a list with output paths and the prepared tables.

--- a/man/projectReport.Rd
+++ b/man/projectReport.Rd
@@ -2,25 +2,47 @@
 % Please edit documentation in R/projectReport.R
 \name{projectReport}
 \alias{projectReport}
-\title{Create a project-ready MIF report from OPEN-PROM results}
+\title{Create a project-ready report from OPEN-PROM results}
 \usage{
-projectReport(.path, openPromFile)
+projectReport(
+  .path,
+  openPromVariables = NULL,
+  openPromFile = NULL,
+  scenario_name = NULL,
+  model = "OPEN-PROM",
+  output_basename = "outputForProject"
+)
 }
 \arguments{
-\item{openPromFile}{A mif file that contains OPEN-PROM results.}
+\item{.path}{A run path used to locate \code{../project-template.csv} and write the
+output files.}
+
+\item{openPromVariables}{A MAgPIE object, a named list of MAgPIE objects, or a
+\code{read.report()}-style nested list (\code{scenario -> model -> magpie}).}
+
+\item{openPromFile}{Optional MIF file path to check and use as fallback input
+when \code{openPromVariables} is \code{NULL}.}
+
+\item{scenario_name}{Optional scenario name(s). Required for unnamed single
+MAgPIE object input.}
+
+\item{model}{Model name to use when it cannot be detected from nested input.}
+
+\item{output_basename}{Base name for the written \code{.mif} and \code{.xlsx} files.}
 }
 \value{
-This function creates a report file specific to each project needs
+Invisibly returns a list with output paths and the prepared tables.
 }
 \description{
-Reads an OPEN-PROM MIF output file, renames variables to match a project
-template using a mapping table, checks units against the project template,
-converts mismatching units (where supported), and writes a standardized MIF
-report (`outputForProject.mif`) for downstream use.
+Renames OPEN-PROM variables to match a project template, checks and converts
+units, keeps five-year periods, removes EU aggregate regions, and writes one
+concatenated project report for all supplied scenarios.
 }
 \examples{
 \dontrun{
-projectReport(.path = "path/to/run", "path/to/mif")
+projectReport(.path = "path/to/run", openPromVariables = reports,
+              scenario_name = "Scenario1")
+projectReport(.path = "path/to/run", openPromFile = "path/to/reporting.mif")
 }
 
 }


### PR DESCRIPTION
Adding these things

- Read the object and not the file.
- Read multiple scenarios and not just a single one.
- Dont have harcoded data, like OPEN-PROM 2.0
- Also check out for indices, always use names.
- Exclude EU region from project specific results.
- Use a name instead of flag for project report. Use NULL for not exporting for project output
- Remove timestamp from scenario name. Only if you want to. Added a flag in postprom.