### PR TITLE
Enhance project report variable mapping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: postprom
 Type: Package
 Title: A Tool for Comparative Analysis of OPEN-PROM Data
-Version: 0.12.11
+Version: 0.12.12
 Authors@R: c(
     person(
       "Michael", "Madianos",

--- a/R/projectReport.R
+++ b/R/projectReport.R
@@ -193,24 +193,9 @@ findProjectTemplatePath <- function(.path, project_template = "project-template.
 
 prepareProjectReportScenario <- function(dataMagpie, project, map) {
   dataMagpie <- flattenProjectReportNames(dataMagpie)
+  dataMagpie <- mapProjectReportVariables(dataMagpie, map)
 
-  varNames <- getItems(dataMagpie, dim = 3)
-  varsClean <- cleanProjectReportVariable(varNames)
-  units <- extractProjectReportUnit(varNames)
-  hasUnits <- !is.na(units)
-
-  map$OPEN_PROM <- trimws(map$OPEN_PROM)
-  rename_lookup <- setNames(trimws(map$project_template), map$OPEN_PROM)
-
-  renamedVars <- varsClean
-  matchedVars <- varsClean %in% names(rename_lookup)
-  renamedVars[matchedVars] <- rename_lookup[varsClean[matchedVars]]
-
-  renamedVarsFinal <- renamedVars
-  renamedVarsFinal[hasUnits] <- paste0(renamedVars[hasUnits], " (", units[hasUnits], ")")
-  getItems(dataMagpie, dim = 3) <- renamedVarsFinal
-
-  renamedClean <- cleanProjectReportVariable(renamedVarsFinal)
+  renamedClean <- cleanProjectReportVariable(getItems(dataMagpie, dim = 3))
   commonVars <- intersect(project$variable, renamedClean)
 
   if (!length(commonVars)) {
@@ -253,6 +238,128 @@ prepareProjectReportScenario <- function(dataMagpie, project, map) {
   finalDataMagpie <- filterProjectReportYears(finalDataMagpie)
 
   return(mbind(finalDataMagpie))
+}
+
+mapProjectReportVariables <- function(dataMagpie, map) {
+  varNames <- getItems(dataMagpie, dim = 3)
+  varsClean <- cleanProjectReportVariable(varNames)
+  units <- extractProjectReportUnit(varNames)
+
+  map$OPEN_PROM <- trimws(map$OPEN_PROM)
+  map$project_template <- trimws(map$project_template)
+  map <- map[map$OPEN_PROM %in% varsClean, , drop = FALSE]
+
+  if (!nrow(map)) {
+    return(dataMagpie)
+  }
+
+  mappedIndex <- match(map$OPEN_PROM, varsClean)
+  passthroughIndex <- setdiff(seq_along(varNames), mappedIndex)
+
+  mappedMagpie <- dataMagpie[, , mappedIndex]
+  mappedNames <- map$project_template
+  mappedHasUnits <- !is.na(units[mappedIndex])
+  mappedNames[mappedHasUnits] <- paste0(
+    mappedNames[mappedHasUnits],
+    " (",
+    units[mappedIndex][mappedHasUnits],
+    ")"
+  )
+  getItems(mappedMagpie, dim = 3) <- mappedNames
+
+  mappedSourceClean <- map$OPEN_PROM
+
+  if (length(passthroughIndex)) {
+    passthroughMagpie <- dataMagpie[, , passthroughIndex]
+    mappedMagpie <- mbind(passthroughMagpie, mappedMagpie)
+    mappedSourceClean <- c(varsClean[passthroughIndex], mappedSourceClean)
+  }
+
+  return(collapseProjectReportDuplicates(mappedMagpie, dataMagpie, mappedSourceClean))
+}
+
+collapseProjectReportDuplicates <- function(dataMagpie, sourceMagpie, sourceClean) {
+  itemNames <- getItems(dataMagpie, dim = 3)
+  targetClean <- cleanProjectReportVariable(itemNames)
+  targetUnits <- extractProjectReportUnit(itemNames)
+  out <- NULL
+
+  for (target in unique(targetClean)) {
+    idx <- which(targetClean == target)
+    unit <- unique(targetUnits[idx][!is.na(targetUnits[idx])])
+    itemName <- target
+    if (length(unit)) itemName <- paste0(target, " (", unit[1], ")")
+
+    if (length(idx) == 1) {
+      item <- dataMagpie[, , idx]
+    } else if (grepl("^Price\\|", target)) {
+      item <- weightedProjectReportPrice(
+        prices = dataMagpie[, , idx],
+        sourceMagpie = sourceMagpie,
+        sourcePriceClean = sourceClean[idx],
+        target = target
+      )
+    } else {
+      item <- dimSums(dataMagpie[, , idx], dim = 3, na.rm = TRUE)
+    }
+
+    getItems(item, dim = 3) <- itemName
+    out <- mbind(out, item)
+  }
+
+  return(out)
+}
+
+weightedProjectReportPrice <- function(prices, sourceMagpie, sourcePriceClean, target) {
+  sourceWeightClean <- sub("^Price\\|", "", sourcePriceClean)
+  sourceNames <- getItems(sourceMagpie, dim = 3)
+  sourceClean <- cleanProjectReportVariable(sourceNames)
+  weightIndex <- match(sourceWeightClean, sourceClean)
+
+  if (anyNA(weightIndex)) {
+    missingWeights <- sourceWeightClean[is.na(weightIndex)]
+    keepWeighted <- !is.na(weightIndex)
+
+    if (any(keepWeighted)) {
+      warning(
+        "Ignoring unweighted price source(s) for '", target,
+        "' because matching final-energy weights were not found for: ",
+        paste(missingWeights, collapse = "; "),
+        call. = FALSE
+      )
+      prices <- prices[, , keepWeighted]
+      sourcePriceClean <- sourcePriceClean[keepWeighted]
+      sourceWeightClean <- sourceWeightClean[keepWeighted]
+      weightIndex <- weightIndex[keepWeighted]
+    } else {
+      warning(
+        "Using arithmetic mean for '", target,
+        "' because matching final-energy weights were not found for: ",
+        paste(missingWeights, collapse = "; "),
+        call. = FALSE
+      )
+      return(dimSums(prices, dim = 3, na.rm = TRUE) / length(sourcePriceClean))
+    }
+  }
+
+  if (length(sourcePriceClean) == 1) {
+    return(prices)
+  }
+
+  weights <- sourceMagpie[, , weightIndex]
+  getItems(weights, dim = 3) <- getItems(prices, dim = 3)
+
+  denominator <- dimSums(weights, dim = 3, na.rm = TRUE)
+  if (any(as.array(denominator) == 0, na.rm = TRUE)) {
+    warning(
+      "Zero final-energy weights found for '", target,
+      "'. Weighted price will be undefined for those cells.",
+      call. = FALSE
+    )
+  }
+
+  numerator <- dimSums(prices * weights, dim = 3, na.rm = TRUE)
+  return(numerator / denominator)
 }
 
 flattenProjectReportNames <- function(dataMagpie) {

--- a/inst/extdata/prom-project-template.csv
+++ b/inst/extdata/prom-project-template.csv
@@ -1,8 +1,12 @@
 project_template,OPEN_PROM
-Capacity Additions|Electricity|Biomass|w/ CCS,Capacity Additions|Electricity|ATHBMSCCS
-Capacity Additions|Electricity|Biomass|w/o CCS,Capacity Additions|Electricity|ATHBMSWAS
-Capacity Additions|Electricity|Coal|w/ CCS,Capacity Additions|Electricity|ATHCOALCCS
-Capacity Additions|Electricity|Gas|w/ CCS,Capacity Additions|Electricity|ATHGASCCS
+Capacity Additions|Electricity|Biomass,Capacity Additions|Electricity|Biofuels
+Capacity Additions|Electricity|Biomass|w/ CCS,Capacity Additions|Electricity|Biofuels|w/ CCS
+Capacity Additions|Electricity|Biomass|w/o CCS,Capacity Additions|Electricity|Biofuels|w/o CCS
+Capacity Additions|Electricity|Non-Biomass Renewables,Capacity Additions|Electricity|Geothermal and other renewable sources
+Capacity|Electricity|Biomass,Capacity|Electricity|Biofuels
+Capacity|Electricity|Biomass|w/ CCS,Capacity|Electricity|Biofuels|w/ CCS
+Capacity|Electricity|Biomass|w/o CCS,Capacity|Electricity|Biofuels|w/o CCS
+Capacity|Electricity|Non-Biomass Renewables,Capacity|Electricity|Geothermal and other renewable sources
 Carbon Capture|Energy|Supply|Electricity|Biomass,Carbon Capture|Energy|Supply|Electricity|Biofuels
 Carbon Capture|Energy|Demand|Industry|Chemicals,Carbon Capture|Energy|Demand|Chemicals
 Carbon Capture|Energy|Demand|Industry|Iron and Steel,Carbon Capture|Energy|Demand|Iron and Steel
@@ -17,6 +21,7 @@ Price|Final Energy|Industry|Chemicals|Electricity,Price|Final Energy|Industry|CH
 Price|Final Energy|Industry|Chemicals|Hydrogen,Price|Final Energy|Industry|CH|H2F
 Price|Final Energy|Industry|Chemicals|Heat,Price|Final Energy|Industry|CH|STE
 Price|Final Energy|Industry|Gases|Other,Price|Final Energy|Industry|Derived gases
+Price|Final Energy|Industry|Gases|Other,Price|Final Energy|Industry|OGS
 Price|Final Energy|Industry|Liquids|Oil,Price|Final Energy|Industry|Diesel oil
 Price|Final Energy|Industry|Liquids|Oil,Price|Final Energy|Industry|Fuel oil
 Price|Final Energy|Industry|Gases,Price|Final Energy|Industry|Gases
@@ -60,7 +65,11 @@ Price|Final Energy|Commercial|Gases,Price|Final Energy|Residential and Commercia
 Price|Final Energy|Commercial|Heat,Price|Final Energy|Residential and Commercial|SE|STE
 Price|Final Energy|Transportation|Liquids|Biomass,Price|Final Energy|Transportation|Biofuels
 Price|Final Energy|Transportation|Gases|Other,Price|Final Energy|Transportation|Derived gases
+Price|Final Energy|Transportation|Gases|Other,Price|Final Energy|Transportation|OGS
 Price|Final Energy|Transportation|Liquids|Oil,Price|Final Energy|Transportation|Diesel oil
+Price|Final Energy|Transportation|Liquids|Oil,Price|Final Energy|Transportation|Fuel oil
+Price|Final Energy|Transportation|Liquids|Oil,Price|Final Energy|Transportation|GDO
+Price|Final Energy|Transportation|Liquids|Oil,Price|Final Energy|Transportation|RFO
 Price|Final Energy|Transportation|Gases,Price|Final Energy|Transportation|Gases
 Price|Final Energy|Transportation|Domestic Shipping|Liquids,Price|Final Energy|Transportation|GN|GDO
 Price|Final Energy|Transportation|Domestic Shipping|Hydrogen,Price|Final Energy|Transportation|GN|H2F
@@ -69,8 +78,10 @@ Price|Final Energy|Transportation|Freight|Liquids,Price|Final Energy|Transportat
 Price|Final Energy|Transportation|Truck|Electricity,Price|Final Energy|Transportation|GU|ELC
 Price|Final Energy|Transportation|Truck|Hydrogen,Price|Final Energy|Transportation|GU|H2F
 Price|Final Energy|Transportation|Hydrogen,Price|Final Energy|Transportation|Hydrogen
+Price|Final Energy|Transportation|Hydrogen,Price|Final Energy|Transportation|H2F
 Price|Final Energy|Transportation|Liquids,Price|Final Energy|Transportation|Liquids
 Price|Final Energy|Transportation|Gases|Gas,Price|Final Energy|Transportation|Natural gas
+Price|Final Energy|Transportation|Gases|Gas,Price|Final Energy|Transportation|NGS
 Price|Final Energy|Transportation|Bus|Electricity,Price|Final Energy|Transportation|PB|ELC
 Price|Final Energy|Transportation|Bus|Liquids,Price|Final Energy|Transportation|PB|GDO
 Price|Final Energy|Transportation|Bus|Hydrogen,Price|Final Energy|Transportation|PB|H2F
@@ -80,3 +91,15 @@ Final Energy|Commercial|ICT|Data Centers,Final Energy|Commercial|Data centers an
 Final Energy|Commercial|ICT|Infrastructure,Final Energy|Commercial|Data centers and Networks|Infrastructure
 Final Energy|Commercial|ICT|Data Centers|Electricity,Final Energy|Commercial|Data centers and Networks|Data Centers|Electricity
 Final Energy|Commercial|ICT|Infrastructure|Electricity,Final Energy|Commercial|Data centers and Networks|Infrastructure|Electricity
+Secondary Energy|Electricity|Biomass,Secondary Energy|Electricity|Biofuels
+Secondary Energy|Electricity|Biomass|w/ CCS,Secondary Energy|Electricity|Biofuels|w/ CCS
+Secondary Energy|Electricity|Biomass|w/o CCS,Secondary Energy|Electricity|Biofuels|w/o CCS
+Secondary Energy|Electricity|Non-Biomass Renewables,Secondary Energy|Electricity|Geothermal and other renewable sources
+Secondary Energy|Heat|Biomass,Secondary Energy|Heat|Biofuels
+Secondary Energy|Heat|Biomass|w/ CCS,Secondary Energy|Heat|Biofuels|w/ CCS
+Secondary Energy|Heat|Biomass|w/o CCS,Secondary Energy|Heat|Biofuels|w/o CCS
+Secondary Energy|Heat|Non-Biomass Renewables,Secondary Energy|Heat|Geothermal and other renewable sources
+Secondary Energy|Hydrogen|Biomass,Secondary Energy|Hydrogen|Biofuels
+Secondary Energy|Hydrogen|Biomass|w/ CCS,Secondary Energy|Hydrogen|Biofuels|w/ CCS
+Secondary Energy|Hydrogen|Biomass|w/o CCS,Secondary Energy|Hydrogen|Biofuels|w/o CCS
+Secondary Energy|Hydrogen|Non-Biomass Renewables,Secondary Energy|Hydrogen|Geothermal and other renewable sources


### PR DESCRIPTION
What changed:

- prom-project-template.csv mappings are now applied row-by-row, so many-to-one mappings are preserved before aggregation.
- Duplicate mapped Price|... project variables are collapsed with a final-energy weighted average using the matching Final Energy|... variables.
- Non-price duplicate mapped variables are summed.
- If matching final-energy weights are missing, it falls back to an arithmetic mean with a warning instead of silently duplicating.