### PR TITLE
Added unreported PRISMA variables and Agriculture as separate sector

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: postprom
 Type: Package
 Title: A Tool for Comparative Analysis of OPEN-PROM Data
-Version: 0.12.17
+Version: 0.12.18
 Authors@R: c(
     person(
       "Michael", "Madianos",
@@ -26,6 +26,11 @@ Authors@R: c(
     person(
       "Songmin", "Yu",
       email = "Songmin.Yu@wsp.com",
+      role = c("aut")
+    )
+    person(
+      "Christos", "Koumparakis",
+      email = "Christos.Koumparakis@wsp.com",
       role = c("aut")
     )
   )

--- a/R/reportFinalEnergy.R
+++ b/R/reportFinalEnergy.R
@@ -115,7 +115,7 @@ reportFinalEnergy <- function(path, regions, years) {
 
   # =========================== Auxiliary variables ======================
   # --------------------------- Residential & Comercial ------------------
-  resCom <- fuel[, , c("Final Energy|Residential", "Final Energy|Commercial", "Final Energy|Agriculture, Fishing, Forestry")]
+  resCom <- fuel[, , c("Final Energy|Residential", "Final Energy|Commercial")]
   resCom <- dimSums(resCom, 3)
   getItems(resCom, 3.1) <- "Final Energy|Residential and Commercial"
   # ============================ Add units ================================

--- a/inst/extdata/prom-project-template.csv
+++ b/inst/extdata/prom-project-template.csv
@@ -103,3 +103,15 @@ Secondary Energy|Hydrogen|Biomass,Secondary Energy|Hydrogen|Biofuels
 Secondary Energy|Hydrogen|Biomass|w/ CCS,Secondary Energy|Hydrogen|Biofuels|w/ CCS
 Secondary Energy|Hydrogen|Biomass|w/o CCS,Secondary Energy|Hydrogen|Biofuels|w/o CCS
 Secondary Energy|Hydrogen|Non-Biomass Renewables,Secondary Energy|Hydrogen|Geothermal and other renewable sources
+Primary Energy|Biomass,Primary Energy|Biofuels
+Primary Energy|Geothermal,Primary Energy|Geothermal and other renewable sources
+Primary Energy|Other,Primary Energy|Other fuels
+Final Energy|Gases,Final Energy|Gas
+Final Energy|Geothermal,Final Energy|Geothermal and other renewable sources
+Final Energy|Other,Final Energy|Other fuels
+Final Energy|Liquids,Final Energy|Fossil Liquids
+Final Energy|Liquids,Final Energy|Biodiesel
+Final Energy|Liquids,Final Energy|Biogasoline
+Final Energy|Liquids,Final Energy|Biokerosene
+Final Energy|Solids,Final Energy|Biomass and Waste
+Final Energy|Agriculture,"Final Energy|Agriculture, Fishing, Forestry"


### PR DESCRIPTION
Added variables not reporting under PRISMA template:

1. Primary Energy|Biomass,Primary Energy|Biofuels
2. Primary Energy|Geothermal,Primary Energy|Geothermal and other renewable sources
3. Primary Energy|Other,Primary Energy|Other fuels
4. Final Energy|Gases,Final Energy|Gas
5. Final Energy|Geothermal,Final Energy|Geothermal and other renewable sources
6. Final Energy|Other,Final Energy|Other fuels
7. Final Energy|Liquids,Final Energy|Fossil Liquids
8. Final Energy|Liquids,Final Energy|Biodiesel
9. Final Energy|Liquids,Final Energy|Biogasoline
10. Final Energy|Liquids,Final Energy|Biokerosene
11. Final Energy|Solids,Final Energy|Biomass and Waste
12. Final Energy|Agriculture,"Final Energy|Agriculture, Fishing, Forestry"

and separated Agriculture sector from Residential and Commercial.