### PR TITLE
Update reportEmissions.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: postprom
 Type: Package
 Title: A Tool for Comparative Analysis of OPEN-PROM Data
-Version: 0.13.0
+Version: 0.13.1
 Authors@R: c(
     person(
       "Michael", "Madianos",

--- a/R/reportEmissions.R
+++ b/R/reportEmissions.R
@@ -109,10 +109,7 @@ reportEmissions <- function(path, regions, years) {
   else if (file.exists(iEmissions_magpie)) "softmif" else "exo"  # fallback for pre-tag gdx
 
   AFOLUCh4N2o <- NULL; extraAFOLU <- NULL; kyotoAfolu <- NULL
-  
-  # Use the old version of AFOLU emissions
-  landEmiMode <- "legacy"
-  
+
   if (landEmiMode == "softmif") {
     if (!file.exists(iEmissions_magpie))
       stop("sLandEmiMode=softmif but iEmissions_magpie.mif is missing at ", iEmissions_magpie)


### PR DESCRIPTION
The AFOLU source is controlled from the OPEN-PROM side via the sLandEmiMode tag (set from softLinkMAgPIE + landUseEmulator in main.gms). To use the legacy/exogenous AFOLU, set `land_use_emulator.source=legacy` in the OPEN-PROM config instead of overriding here.